### PR TITLE
Chronology parameter struct, temporal resolution, detachEndings and more

### DIFF
--- a/src/core/Events.h
+++ b/src/core/Events.h
@@ -30,11 +30,21 @@ std::ostream& operator<<(std::ostream& os, struct Set<T> const &s){
     return os;
 }
 
+// Self-explanatory
+
 template <typename T>
 bool isStart(T const& e) { return true; }
 
 template <typename T>
 bool correspond(T const& e1, T const& e2) { return false; }
+
+// Determines if compEvent is an ending event matching refEvent
+
+template <typename T>
+bool isMatchingEnd(T const& refEvent, T const& compEvent) {
+  return Events::correspond<T>(refEvent, compEvent)
+      && !Events::isStart<T>(compEvent);
+}
 
 template <typename T>
 bool hasStart(std::vector<T> const& events) {
@@ -42,6 +52,25 @@ bool hasStart(std::vector<T> const& events) {
         if (isStart<T>(e))
             return true;
     return false;
+}
+
+template <typename T>
+void mergeSets(Events::Set<T>& greaterSet, Events::Set<T> const& mergedSet) {
+  greaterSet.events.insert(
+    greaterSet.events.end(),
+    mergedSet.events.begin(),
+    mergedSet.events.end()
+  );
+}
+
+template <typename T>
+
+void mergeSets(Events::Set<T>& greaterSet, std::vector<T> const& mergedSet){
+    greaterSet.events.insert(
+        greaterSet.events.end(),
+        mergedSet.begin(),
+        mergedSet.end()
+    );
 }
 
 template <typename T>

--- a/src/core/Renderer.h
+++ b/src/core/Renderer.h
@@ -38,8 +38,9 @@ public:
     // ----------------------CONSTRUCTORS/DESTRUCTORS---------------------------
     // -------------------------------------------------------------------------
 
-    Renderer() : lastEventPulled(false), modelEvents(Chronology<Model>(false)) {}
-    Renderer(bool completeEvents) : lastEventPulled(false), modelEvents(Chronology<Model>(completeEvents)) {}
+    Renderer() : lastEventPulled(false), modelEvents(Chronology<Model>()) {}
+    Renderer(ChronologyParams::parameters params) :
+        lastEventPulled(false), modelEvents(Chronology<Model>(params)) {}
 
     // -------------------------------------------------------------------------
     // ---------------------------PUBLIC METHODS--------------------------------
@@ -149,8 +150,16 @@ public:
                 if (map3.find(key) == map3.end() && !lastEventPulled)
                     throw std::runtime_error("INVALID MAP ENTRY FOR KEY");
             } catch (std::runtime_error e) {
+                // Original idea (early 2022) :
                 // This can only happen if two controllers pressed the same key on the same channel
                 // This should not happen
+
+                // Update 08/07/22 ; this is FAR more common than we thought.
+                // For example, this happens if the system is launched with a key already held;
+                // The release of that key will trigger the exception because no note was associated with the key.
+
+                // This causes an instant segfault in the ossia binding.
+                // So the question is, should we keep it that way ?
                 std::cout << e.what() << std::endl;
                 exit(1);
             }
@@ -175,6 +184,10 @@ public:
     void setPartition(Chronology<Model> const newPartition){
         this->clear();
         modelEvents = newPartition;
+    }
+
+    Chronology<Model> getPartition(){
+        return modelEvents;
     }
 
 };

--- a/src/impl/MFPEvents.h
+++ b/src/impl/MFPEvents.h
@@ -2,9 +2,24 @@
 #define MFP_MFPEVENTS_H
 
 #include <iostream>
+#include <string>
 #include <cstdint>
 #include <vector>
 #include "../core/Events.h"
+
+std::string noteNames[12] = {"A","A#","B","C","C#","D","D#","E","F","F#","G","G#"};
+
+std::string convertIdToNoteName(uint8_t id){
+    if(id < 21 || id > 108) return "??";
+
+    uint8_t relativeId = id - 21;
+
+    uint8_t name = (relativeId % 12);
+    uint8_t pitch = (relativeId / 12);
+    if(name > 2) pitch++;
+
+    return noteNames[name]+std::to_string(pitch);
+}
 
 // NB : commandKey and noteKey structs are for use as std::map keys
 
@@ -16,8 +31,10 @@ struct commandData {
 };
 
 std::ostream& operator<<(std::ostream& os, struct commandData const &cmd){
+    std::string name = convertIdToNoteName(cmd.id);
     return os << "[ pressed : " << cmd.pressed << " , " <<
-    "id : " << int(cmd.id) << " , " <<
+    "id : " << int(cmd.id) <<
+    " (" << name << "), " <<
     "velocity : " << int(cmd.velocity) << " , " <<
     "channel : " << int(cmd.channel) << " ]";
 }
@@ -44,8 +61,10 @@ struct noteData {
 };
 
 std::ostream& operator<<(std::ostream& os, struct noteData const &note){
+    std::string name = convertIdToNoteName(note.pitch);
     return os << "[ on : " << note.on << " , " <<
-    "id : " << int(note.pitch) << " , " <<
+    "pitch : " << int(note.pitch) <<
+    " (" << name << "), " <<
     "velocity : " << int(note.velocity) << " , " <<
     "channel : " << int(note.channel) << " ]";
 }

--- a/src/impl/MFPRenderer.h
+++ b/src/impl/MFPRenderer.h
@@ -3,6 +3,7 @@
 
 #include "MFPEvents.h"
 #include "../core/Renderer.h"
+#include "../core/Chronology.h"
 
 /*
 // INHERITANCE
@@ -57,6 +58,10 @@ private:
   }
 
 public:
+
+  MFPRenderer() : renderer() {}
+  MFPRenderer(ChronologyParams::parameters params) : renderer(params) {}
+
   void pushEvent(int dt, noteData event) { renderer.pushEvent(dt, event); }
 
   void finalize() { renderer.finalize(); }
@@ -78,6 +83,8 @@ public:
   void clear() { renderer.clear(); }
 
   void setPartition(Chronology<noteData> const newPartition){ renderer.setPartition(newPartition); }
+
+  Chronology<noteData> getPartition() { return renderer.getPartition(); }
 };
 //*/
 


### PR DESCRIPTION
This is a large commit that should have been split into many.

MAJOR :

1. detachEndings method

Chronology objects now have a detachEndings method that, when a start
event and its corresponding end are in the same set, separates them
as the chronology is finalized. This is used to prevent "shadow notes"
which are a common phenomenon in MIDI files for an unknown reason.

2. Temporal resolution

A Chronology can now be set to merge all events which dt is less than a
set threshold, rather than only merge events with a dt of 0.
More experiments need to be done on this matter ; the "correct" value
has not yet been found.

3. ChronologyParams::parameters and its presets

A namespace called ChronologyParams now hosts a type named "parameters",
which is a struct used to pass all parameters used in the Chronology
constructor (a la JavaScript). It must be initialized LIKE a struct,
as it was purposely left without constructors ; this is so the values
are NAMED for better clarity.

Presets have been made available : one for a general-purpose,
unmeet-enabled Chronology, and another one with unmeet turned off.
Both offer a temporal resolution of 0. This means they go unused
for the moment.

Renderers and MFPRenderers can use this same exact struct as an argument
to their constructors to set up their inner chronology.

------------------------------------------------------------------------

MINOR :

1. Moved mergeSets() and isMatchingEnd() to the Events.h file.
It was more semantically appropriate.

2. Made the Chronology type "iterable" ; one can run an enhanced 
for-loop
over it. Its begin() and end() iterators are simply those of its fifo.

3. Added the Renderer.getPartition() method.

4. Improved the display (via << ) of MFPEvents, so that they display
not only their MIDI note ID (e.g. 76) but the corresponding note
(in this case, E5).