### PR TITLE
Added an overload for correspond and isMatchingEnd and changed shift …

### DIFF
--- a/src/include/core/Chronology.h
+++ b/src/include/core/Chronology.h
@@ -23,14 +23,14 @@ namespace ChronologyParams{
         uint64_t date; // Unused for now, purpose unknown
     };
 
-    static parameters const default_params = {
+    static parameters constexpr default_params = {
         .unmeet = true,
         .complete = false,
         .temporalResolution = 0,
         .date = 0
     };
 
-    static parameters const no_unmeet = {
+    static parameters constexpr no_unmeet = {
         .unmeet = false,
         .complete = false,
         .temporalResolution = 0,
@@ -130,12 +130,13 @@ private:
       if (!Events::hasStart<T>(inputSet)) {
 
         Events::mergeSets(bufferSet,inputSet);
+        bufferSet.dt += inputSet.dt;
         if (last) fifo.push_back(bufferSet);
         return;
 
       } else { // the inputSet is a starting set (it has a least one start event)
 
-        // Guard against pushing an ending set in the first position of the fifo
+        // Guard against pushing an empty set in the first position of the fifo
         // Pushing an empty set in other cases is fine, it is an artifical ending
 
         if (!fifo.empty()) {
@@ -166,7 +167,7 @@ private:
         fifo.push_back(insertSet);
 
         // If it IS empty, register the bufferSet as incomplete.
-        if (insertSet.events.empty())
+        if (params.complete && insertSet.events.empty())
             incompleteEvents.push_back({bufferSet,&fifo.back()});
       }
 

--- a/src/include/core/Events.h
+++ b/src/include/core/Events.h
@@ -44,11 +44,22 @@ bool isStart(T const& e) { return true; }
 template <typename T>
 bool correspond(T const& e1, T const& e2) { return false; }
 
+enum class correspondOption : int; //define in implementations
+
+template <typename T>
+bool correspond(T const& e1, T const& e2, correspondOption o) { return false; }
+
 // Determines if compEvent is an ending event matching refEvent
 
 template <typename T>
 bool isMatchingEnd(T const& refEvent, T const& compEvent) {
   return Events::correspond<T>(refEvent, compEvent)
+      && !Events::isStart<T>(compEvent);
+}
+
+template <typename T>
+bool isMatchingEnd(T const& refEvent, T const& compEvent, correspondOption o) {
+  return Events::correspond<T>(refEvent, compEvent, o)
       && !Events::isStart<T>(compEvent);
 }
 
@@ -61,6 +72,8 @@ bool hasStart(std::vector<T> const& events) {
 }
 
 template <typename T>
+
+// Merging at the beginning of a vector should be avoided, it is an inefficient operation that requires element shifting
 
 void mergeSets(Events::Set<T>& greaterSet, std::vector<T> const& mergedSet, int mergePoint=MERGE_AT_END){
     typename std::vector<T>::iterator it;

--- a/src/include/impl/MFPEvents.h
+++ b/src/include/impl/MFPEvents.h
@@ -83,6 +83,10 @@ struct noteKey {
     };
 };
 
+namespace Events {
+    enum class correspondOption { PITCH_AND_CHANNEL, PITCH_ONLY, NONE };
+}
+
 /* * * * * * * * * * * * * specializations for commands * * * * * * * * * * * */
 
 template<>
@@ -91,6 +95,11 @@ inline bool Events::isStart<commandData>(commandData const& cmd) { return cmd.pr
 template<>
 inline bool Events::correspond<commandData>(commandData const& cmd1, commandData const& cmd2) {
     return cmd1.id == cmd2.id && cmd1.channel == cmd2.channel;
+}
+
+template<>
+inline bool Events::correspond<commandData>(commandData const& cmd1, commandData const& cmd2, correspondOption o) {
+    return (o!=correspondOption::NONE) && cmd1.id == cmd2.id && (o==correspondOption::PITCH_ONLY || cmd1.channel == cmd2.channel);
 }
 
 template <>
@@ -104,8 +113,8 @@ template<>
 inline bool Events::isStart<noteData>(noteData const& note) { return note.on; }
 
 template<>
-inline bool Events::correspond<noteData>(noteData const& note1, noteData const& note2) {
-    return note1.pitch == note2.pitch && note1.channel == note2.channel;
+inline bool Events::correspond<noteData>(noteData const& note1, noteData const& note2, correspondOption o) {
+    return (o!=correspondOption::NONE) && note1.pitch == note2.pitch && (o==correspondOption::PITCH_ONLY || note1.channel == note2.channel);
 }
 
 template <>


### PR DESCRIPTION
…logic

correspond and isMatchingEnd can now take a third argument of type 
"correspondOption", which is an enum class. The enumerators are only 
accessible through the specialization file. 

There are three enumerators : PITCH_AND_CHANNEL (the default, since it 
is 0 ; note that the default params for a Chronology now DO NOT 
INITIALIZE its shiftMode, using this default value instead), PITCH_ONLY 
and NONE. 

shiftSameEventEndings is now systematically called, but uses 
isMatchingEnd with the provided shiftMode.

The method's logic was also rewritten because its previous version 
erroneously caused events to be discarded from sets, resulting in 
missing notes - which is a rather critical bug.