### PR TITLE
Removed IME exception and fixed note stealing issue

### DIFF
--- a/src/include/core/Renderer.h
+++ b/src/include/core/Renderer.h
@@ -6,7 +6,7 @@
 #include <map>
 #include "Chronology.h"
 
-template <typename Model, typename Command, typename CommandKey, typename NoteKey>
+template <typename Model, typename Command, typename CommandKey, typename ModelKey>
 class Renderer {
 
     // -------------------------------------------------------------------------
@@ -29,7 +29,7 @@ class Renderer {
 
     std::map<CommandKey, std::vector<Model>> map3; // A map between a start event
     // and its correspondent ending.
-    std::map<NoteKey, CommandKey> antiStealMap; // A map keeping track of which key
+    std::map<ModelKey, CommandKey> antiStealMap; // A map keeping track of which key
     // is associated with each combination of pitch and channel,
     // in order to prevent voice stealing.
 
@@ -95,7 +95,7 @@ public:
     // the commandEvents chronology.
 
     virtual std::vector<Model> combine3(Command cmd) {
-        CommandKey key = Events::keyFromData<Command, CommandKey>(cmd);
+        CommandKey commandKey = Events::keyFromData<Command, CommandKey>(cmd);
         std::vector<Model> emptyEvents = {};
 
         // If the command is a key press, search for the next event.
@@ -109,26 +109,27 @@ public:
             // If so, delete this note-pitch combination's release
             // from the set of release events assigned to that other key's release.
 
-            for(Model& event : events){
-                NoteKey note = Events::keyFromData<Model, NoteKey>(event);
+            for (Model& event : events) {
+                ModelKey modelKey = Events::keyFromData<Model, ModelKey>(event);
 
-                if(antiStealMap.find(note)!=antiStealMap.end()){
+                if (antiStealMap.find(note) != antiStealMap.end()) {
 
                     // This means this pitch-channel combination is associated
                     // with another key.
 
-                    CommandKey assignedKey = antiStealMap[note];
-                    std::vector<Model>& endEvents = map3[assignedKey];
+                    CommandKey assignedCommandKey = antiStealMap[modelKey];
+                    std::vector<Model>& endEvents = map3[assignedCommandKey];
                     auto it = endEvents.begin();
 
-                    while(it!=endEvents.end()){
-                        if(it->pitch == note.pitch && it->channel == note.channel)
-                            it=endEvents.erase(it); // prevent the other key from releasing the note
+                    while (it != endEvents.end()){
+                        if (correspond(*it, modelKey))
+                        // if(it->pitch == note.pitch && it->channel == note.channel)
+                            it = endEvents.erase(it); // prevent the other key from releasing the note
                         else it++;
                     }
                 }
 
-                antiStealMap[note] = key; // register the new key as this note's owner
+                antiStealMap[modelKey] = commandKey; // register the new key as this note's owner
             }
 
             // Then, if the event set that has been pulled is a starting set
@@ -151,11 +152,11 @@ public:
                 }
 
                 /*std::cout << "C++ debug : " << cmd << " associated with ";
-                if(!nextEvents.empty()){
-                    for(Model& e : nextEvents){
+                if (!nextEvents.empty()) {
+                    for (Model& e : nextEvents) {
                         std::cout << e << std::endl;
                     }
-                }else{
+                } else {
                     std::cout << "no release events" << std::endl;
                 }*/
 
@@ -166,14 +167,14 @@ public:
                 // If this same key already has events registered in the combine map,
                 // Trigger them, and then register the new ones.
 
-                if(map3.find(key) != map3.end()){
-                    std::vector<Model> extraEvents = map3[key];
-                    events.insert(events.end(),extraEvents.begin(),extraEvents.end());
+                if (map3.find(key) != map3.end()) {
+                    std::vector<Model> extraEvents = map3[commandKey];
+                    events.insert(events.end(), extraEvents.begin(), extraEvents.end());
                     // Should we rather append them to nextEvents ?
                 }
 
                 // Map the key to this event, so as to bind its release to it.
-                map3[key] = nextEvents;
+                map3[commandKey] = nextEvents;
 
                 return events;
 
@@ -186,15 +187,15 @@ public:
 
             //std::cout << "end command" << std::endl;
 
-            if (map3.find(key) == map3.end() && !lastEventPulled)
-                    return emptyEvents;
+            if (map3.find(commandKey) == map3.end() && !lastEventPulled)
+                return emptyEvents;
 
-            std::vector<Model> events = map3[key];
+            std::vector<Model> events = map3[commandKey];
             if (events.empty() && !orphanedEndings.empty()) {
                 events = orphanedEndings.front();
                 orphanedEndings.pop_front();
             }
-            map3.erase(key);
+            map3.erase(commandKey);
             return events;
         }
     }
@@ -206,7 +207,7 @@ public:
     // Replace the partition chronology entirely.
     // DEEP COPY so that the original partition will be left unmodified.
 
-    void setPartition(Chronology<Model> const newPartition){
+    void setPartition(Chronology<Model> const newPartition) {
         this->clear();
         modelEvents = newPartition;
     }

--- a/src/include/core/Renderer.h
+++ b/src/include/core/Renderer.h
@@ -112,7 +112,7 @@ public:
             for (Model& event : events) {
                 ModelKey modelKey = Events::keyFromData<Model, ModelKey>(event);
 
-                if (antiStealMap.find(note) != antiStealMap.end()) {
+                if (antiStealMap.find(modelKey) != antiStealMap.end()) {
 
                     // This means this pitch-channel combination is associated
                     // with another key.
@@ -122,8 +122,7 @@ public:
                     auto it = endEvents.begin();
 
                     while (it != endEvents.end()){
-                        if (correspond(*it, modelKey))
-                        // if(it->pitch == note.pitch && it->channel == note.channel)
+                        if (Events::correspond<Model>(*it, event))
                             it = endEvents.erase(it); // prevent the other key from releasing the note
                         else it++;
                     }

--- a/src/include/core/Renderer.h
+++ b/src/include/core/Renderer.h
@@ -167,7 +167,7 @@ public:
                 // If this same key already has events registered in the combine map,
                 // Trigger them, and then register the new ones.
 
-                if (map3.find(key) != map3.end()) {
+                if (map3.find(commandKey) != map3.end()) {
                     std::vector<Model> extraEvents = map3[commandKey];
                     events.insert(events.end(), extraEvents.begin(), extraEvents.end());
                     // Should we rather append them to nextEvents ?

--- a/src/include/impl/MFPEvents.h
+++ b/src/include/impl/MFPEvents.h
@@ -113,6 +113,11 @@ template<>
 inline bool Events::isStart<noteData>(noteData const& note) { return note.on; }
 
 template<>
+inline bool Events::correspond<noteData>(noteData const& note1, noteData const& note2) {
+    return (note1.pitch == note2.pitch && note1.channel == note2.channel);
+}
+
+template<>
 inline bool Events::correspond<noteData>(noteData const& note1, noteData const& note2, correspondOption o) {
     return (o!=correspondOption::NONE) && note1.pitch == note2.pitch && (o==correspondOption::PITCH_ONLY || note1.channel == note2.channel);
 }

--- a/src/include/impl/MFPRenderer.h
+++ b/src/include/impl/MFPRenderer.h
@@ -9,7 +9,7 @@
 class MFPRenderer {
 private:
   std::shared_ptr<ChordVelocityMapping::Strategy> chordStrategy;
-  Renderer<noteData, commandData, commandKey> renderer;
+  Renderer<noteData, commandData, commandKey, noteKey> renderer;
 
   void adjustToCommandVelocity(std::vector<noteData>& notes,
                                uint8_t cmd_velocity) const {


### PR DESCRIPTION
Because the IME case was found to be a false positive in any case it was 
fired (since it was always a single-controller case where no event has 
been found, and these could be caused by trivial situations like 
starting the program with keys already held down), the exception was 
removed entirely. 

However, to compensate, if a key already has a set of associated release 
events, these are triggered with the key press. It is debatable whether 
this is the most intuitive choice (rather than triggering them together 
with the key release). 

As well, voice stealing (the phenomenon in which two keys share one or 
more pitches on the same channel and one will prematurely end the 
other's events) has been addressed with a separate map transferring any 
ending events to the most recent key associated with their beginnings.

These solutions have been tested in the score binding and seem to work. 
Their effect on the MFP's complexity and expressiveness as a TIMS should 
be evaluated formally to ensure they do not cause a loss similar to the 
deactivation of the unmeet transformation.